### PR TITLE
Dev

### DIFF
--- a/internal/routes/get_wifi_nearby_handler.go
+++ b/internal/routes/get_wifi_nearby_handler.go
@@ -10,7 +10,74 @@ import (
 	"wifi-go-backend/internal/models"
 
 	"github.com/julienschmidt/httprouter"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
+
+func (h *Handlers) WiFiConnect(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	// Parse request body for wifi_id and location
+	type ConnectRequest struct {
+		WiFiID    string  `json:"wifi_id"`
+		Latitude  float64 `json:"latitude"`
+		Longitude float64 `json:"longitude"`
+	}
+	var req ConnectRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("Invalid request body"))
+		return
+	}
+
+	if req.WiFiID == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("wifi_id is required"))
+		return
+	}
+
+	coll, err := db.GetWiFiCollection()
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("Database connection error"))
+		return
+	}
+
+	// Find WiFi by ID
+	var wifi models.WiFi
+	objID, err := primitive.ObjectIDFromHex(req.WiFiID)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("Invalid wifi_id"))
+		return
+	}
+	err = coll.FindOne(r.Context(), map[string]interface{}{"_id": objID}).Decode(&wifi)
+	if err != nil {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte("WiFi not found"))
+		return
+	}
+
+	// Check if the provided location is within 100 meters of the WiFi
+	if len(wifi.Location.Coordinates) != 2 {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("WiFi location data invalid"))
+		return
+	}
+	wifiLng := wifi.Location.Coordinates[0]
+	wifiLat := wifi.Location.Coordinates[1]
+	dist := haversine(req.Latitude, req.Longitude, wifiLat, wifiLng)
+	if dist > 0.1 {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte("You are too far from this WiFi to connect"))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"ssid":        wifi.SSID,
+		"password":    wifi.Password,
+		"location":    wifi.Location,
+		"description": wifi.Description,
+	})
+}
 
 func (h *Handlers) WiFiNearby(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	// Parse query params for latitude and longitude

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -1,16 +1,12 @@
 package routes
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"wifi-go-backend/config"
 	"wifi-go-backend/internal/auth"
-	"wifi-go-backend/internal/db"
-	"wifi-go-backend/internal/models"
 
 	"github.com/julienschmidt/httprouter"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 // Handlers struct for dependency injection
@@ -33,72 +29,6 @@ func (h *Handlers) AuthMe(w http.ResponseWriter, r *http.Request, _ httprouter.P
 
 func (h *Handlers) AuthUpgrade(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	// TODO: Upgrade verification level
-}
-
-func (h *Handlers) WiFiConnect(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	// Parse request body for wifi_id and location
-	type ConnectRequest struct {
-		WiFiID    string  `json:"wifi_id"`
-		Latitude  float64 `json:"latitude"`
-		Longitude float64 `json:"longitude"`
-	}
-	var req ConnectRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte("Invalid request body"))
-		return
-	}
-
-	if req.WiFiID == "" {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte("wifi_id is required"))
-		return
-	}
-
-	coll, err := db.GetWiFiCollection()
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("Database connection error"))
-		return
-	}
-
-	// Find WiFi by ID
-	var wifi models.WiFi
-	objID, err := primitive.ObjectIDFromHex(req.WiFiID)
-	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte("Invalid wifi_id"))
-		return
-	}
-	err = coll.FindOne(r.Context(), map[string]interface{}{"_id": objID}).Decode(&wifi)
-	if err != nil {
-		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte("WiFi not found"))
-		return
-	}
-
-	// Check if the provided location is within 100 meters of the WiFi
-	if len(wifi.Location.Coordinates) != 2 {
-		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("WiFi location data invalid"))
-		return
-	}
-	wifiLng := wifi.Location.Coordinates[0]
-	wifiLat := wifi.Location.Coordinates[1]
-	dist := haversine(req.Latitude, req.Longitude, wifiLat, wifiLng)
-	if dist > 0.1 {
-		w.WriteHeader(http.StatusForbidden)
-		w.Write([]byte("You are too far from this WiFi to connect"))
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{
-		"ssid":        wifi.SSID,
-		"password":    wifi.Password,
-		"location":    wifi.Location,
-		"description": wifi.Description,
-	})
 }
 
 func (h *Handlers) WiFiSaved(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {


### PR DESCRIPTION
This pull request refactors the `WiFiConnect` handler by moving its implementation from `internal/routes/routes.go` to a dedicated file, `internal/routes/get_wifi_nearby_handler.go`. Additionally, it removes unused imports and simplifies the `routes.go` file.

### Refactoring and Code Organization:

* **Relocation of `WiFiConnect` Handler**: The `WiFiConnect` handler was moved from `internal/routes/routes.go` to `internal/routes/get_wifi_nearby_handler.go`, improving modularity and code organization. [[1]](diffhunk://#diff-59b190ee29fa86fbd27170fd51cfb5aecc5fb1e31a1b080ca9b00d4717f3eed8R13-R81) [[2]](diffhunk://#diff-8916c4df6a76d9a9d01c7411922d5f980c5cbaad5848ecf18679e294645712d0L38-L103)

### Code Cleanup:

* **Removed Unused Imports**: Unnecessary imports such as `encoding/json`, `wifi-go-backend/internal/db`, `wifi-go-backend/internal/models`, and `go.mongodb.org/mongo-driver/bson/primitive` were removed from `internal/routes/routes.go` to reduce clutter.